### PR TITLE
IE8 and below have issues with 'no-cache' headers

### DIFF
--- a/code/SecureFileController.php
+++ b/code/SecureFileController.php
@@ -166,6 +166,7 @@ class SecureFileController extends Controller implements PermissionProvider {
 		$mimeType = HTTP::getMimeType($file_name);
 		header("Content-Type: {$mimeType}; name=\"" . addslashes($file_name) . "\"");
 		header("Content-Disposition: attachment; filename=" . addslashes($file_name));
+		header("Cache-Control: max-age=1, private");
 		header("Content-Length: {$file_size}");
 		header("Pragma: ");
 		


### PR DESCRIPTION
IE8 and below have issues with 'no-cache' headers (see: http://support.microsoft.com/kb/316431). Set the Cache-Control header explicitly to avoid this problem in case the server would otherwise be serving the file with no-cache specified.
