### PR TITLE
Altered call to extend('onAccessDenied') to allow message changes.

### DIFF
--- a/code/SecureFileController.php
+++ b/code/SecureFileController.php
@@ -108,7 +108,7 @@ class SecureFileController extends Controller implements PermissionProvider {
 				return $this->fileFound($file, $file_path);
 			} else {
 				$body = $file->extend('onAccessDenied');
-				if ($body == null) $body[] = "Not Authorized";
+				if ($body == null) $body[] = _t('SecureFiles.NOTAUTHORIZED', 'Not Authorized');
 				return $this->fileNotAuthorized(implode($body));
 			}
 		} else {

--- a/code/SecureFileController.php
+++ b/code/SecureFileController.php
@@ -107,8 +107,9 @@ class SecureFileController extends Controller implements PermissionProvider {
 				$file->extend('onAccessGranted');
 				return $this->fileFound($file, $file_path);
 			} else {
-				$file->extend('onAccessDenied');
-				return $this->fileNotAuthorized("Not Authorized");
+				$body = $file->extend('onAccessDenied');
+				if ($body == null) $body[] = "Not Authorized";
+				return $this->fileNotAuthorized(implode($body));
 			}
 		} else {
 			return $this->fileNotFound("Not Found");

--- a/lang/en_GB.php
+++ b/lang/en_GB.php
@@ -14,6 +14,7 @@ $lang['en_GB']['SecureFiles']['SECUREFOLDER'] = 'Folder is secure.';
 $lang['en_GB']['SecureFiles']['FOLDERSECURITY'] = 'Folder Security';
 $lang['en_GB']['SecureFiles']['NONE'] = '(None)';
 $lang['en_GB']['SecureFiles']['NEVEREXPIRES'] =  'Never';
+$lang['en_GB']['SecureFiles']['NOTAUTHORIZED'] = 'Not Authorised';
 
 // GROUP PERMISSION
 $lang['en_GB']['SecureFiles']['GROUPACCESSTITLE'] = 'Group Access';

--- a/lang/en_US.php
+++ b/lang/en_US.php
@@ -14,6 +14,7 @@ $lang['en_US']['SecureFiles']['SECUREFOLDER'] = 'Folder is secure.';
 $lang['en_US']['SecureFiles']['FOLDERSECURITY'] = 'Folder Security';
 $lang['en_US']['SecureFiles']['NONE'] = '(None)';
 $lang['en_US']['SecureFiles']['NEVEREXPIRES'] =  'Never';
+$lang['en_US']['SecureFiles']['NOTAUTHORIZED'] = 'Not Authorized';
 
 // GROUP PERMISSION
 $lang['en_US']['SecureFiles']['GROUPACCESSTITLE'] = 'Group Access';

--- a/lang/nl_NL.php
+++ b/lang/nl_NL.php
@@ -15,6 +15,7 @@ $lang['nl_NL']['SecureFiles']['SECUREFOLDER'] = 'Map is beveiligd.';
 $lang['nl_NL']['SecureFiles']['FOLDERSECURITY'] = 'Map beveiliging';
 $lang['nl_NL']['SecureFiles']['NONE'] = '(Geen)';
 $lang['nl_NL']['SecureFiles']['NEVEREXPIRES'] =  'Nooit';
+$lang['nl_NL']['SecureFiles']['NOTAUTHORIZED'] = 'Geen toestemming';
 
 // GROUP PERMISSION
 $lang['nl_NL']['SecureFiles']['GROUPACCESSTITLE'] = 'Groepstoegang';


### PR DESCRIPTION
As far as I can tell the current extend('onAccessDenied') doesn't allow for customisation of the failure message displayed to the user. I've altered the call to extend('onAccessDenied') to allow overriding of permission failure message. 

Sample code to extend the message:

mysite/code/FileMessage.php
<code><?php
class FileMessage extends DataObjectDecorator {
    function onAccessDenied($body) {
        return "You have to login before you can access this file. You can create an account for free.";
    }
</code>

mysite/_config.php
<code>DataObject::add_extension('File', 'FileMessage');</code>

If user doesn't have permission he/she is shown a custom friendly message at the login screen.
